### PR TITLE
Add get_session arg to Middleware

### DIFF
--- a/src/session_header/middleware.py
+++ b/src/session_header/middleware.py
@@ -3,8 +3,8 @@ from django.contrib.sessions import middleware
 
 
 class SessionMiddleware(middleware.SessionMiddleware):
-    def __init__(self):
-        super(SessionMiddleware, self).__init__()
+    def __init__(self, get_response=None):
+        super(SessionMiddleware, self).__init__(get_response)
         bases = (SessionHeaderMixin, self.SessionStore)
         self.SessionStore = type('SessionStore', bases, {})
 


### PR DESCRIPTION
Add `get_session` argument to the middleware constructor, introduced in Django 1.10 https://docs.djangoproject.com/en/1.10/_modules/django/contrib/sessions/middleware/#SessionMiddleware
⚠️ this might not be backward compatible ⚠️
I am not sure how to support multiple django versions, so if you have any suggestions, please let know!